### PR TITLE
Trigger conversion only after form submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,16 +17,6 @@
   twq('config','q9dv5');
   </script>
   <!-- End Twitter conversion tracking base code -->
-  <!-- Twitter conversion tracking event code -->
-  <script type="text/javascript">
-    // Insert Twitter Event ID
-    twq('event', 'tw-q9dv5-q9dv7', {
-      conversion_id: null, // use this to pass a unique ID for the conversion event for deduplication (e.g. order id '1a2b3c')
-      email_address: null, // use this to pass a user’s email address
-      phone_number: null // phone number in E164 standard
-    });
-  </script>
-  <!-- End Twitter conversion tracking event code -->
 </head>
 <body>
   <div class="overlay">

--- a/script.js
+++ b/script.js
@@ -603,4 +603,9 @@ function submitForm() {
     input.value = formData[key];
   });
   fetch('/', { method: 'POST', body: fd });
+  twq('event', 'tw-q9dv5-q9dv7', {
+    conversion_id: null, // use this to pass a unique ID for the conversion event for deduplication (e.g. order id '1a2b3c')
+    email_address: null, // use this to pass a user’s email address
+    phone_number: null // phone number in E164 standard
+  });
 }


### PR DESCRIPTION
## Summary
- remove Twitter conversion event from page load
- fire Twitter conversion event after lead form submission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c079607e3c83319dfc6cefb3d595e9